### PR TITLE
Moving armv7 to optional GHA build

### DIFF
--- a/.github/workflows/04-add-metadata.yaml
+++ b/.github/workflows/04-add-metadata.yaml
@@ -52,4 +52,8 @@ jobs:
 #NEW: (END) ############################################################
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          # comma seperated list of what OS and architechtures to build for (in parallel)
+          # default is linux/amd64 (the OS of the runner) but you can add more
+          # adding linux/arm64 is recommended for Apple Silicon, Raspberry Pi, AWS Graviton, etc.
+          # linux/arm/v7 is for 32-bit ARM devices like Raspberry Pi 2/3
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/05-add-comment.yaml
+++ b/.github/workflows/05-add-comment.yaml
@@ -53,7 +53,11 @@ jobs:
           labels: ${{ steps.docker_meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          # comma seperated list of what OS and architechtures to build for (in parallel)
+          # default is linux/amd64 (the OS of the runner) but you can add more
+          # adding linux/arm64 is recommended for Apple Silicon, Raspberry Pi, AWS Graviton, etc.
+          # linux/arm/v7 is for 32-bit ARM devices like Raspberry Pi 2/3
+          platforms: linux/amd64,linux/arm64
 
 
 #NEW: (START) ##########################################################

--- a/.github/workflows/06-add-cve-scanning.yaml
+++ b/.github/workflows/06-add-cve-scanning.yaml
@@ -69,4 +69,8 @@ jobs:
           labels: ${{ steps.docker_meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          # comma seperated list of what OS and architechtures to build for (in parallel)
+          # default is linux/amd64 (the OS of the runner) but you can add more
+          # adding linux/arm64 is recommended for Apple Silicon, Raspberry Pi, AWS Graviton, etc.
+          # linux/arm/v7 is for 32-bit ARM devices like Raspberry Pi 2/3
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/07-add-cve-scanning-adv.yaml
+++ b/.github/workflows/07-add-cve-scanning-adv.yaml
@@ -97,4 +97,8 @@ jobs:
           labels: ${{ steps.docker_meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          # comma seperated list of what OS and architechtures to build for (in parallel)
+          # default is linux/amd64 (the OS of the runner) but you can add more
+          # adding linux/arm64 is recommended for Apple Silicon, Raspberry Pi, AWS Graviton, etc.
+          # linux/arm/v7 is for 32-bit ARM devices like Raspberry Pi 2/3
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/08-add-unit-test.yaml
+++ b/.github/workflows/08-add-unit-test.yaml
@@ -67,4 +67,8 @@ jobs:
           labels: ${{ steps.docker_meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          # comma seperated list of what OS and architechtures to build for (in parallel)
+          # default is linux/amd64 (the OS of the runner) but you can add more
+          # adding linux/arm64 is recommended for Apple Silicon, Raspberry Pi, AWS Graviton, etc.
+          # linux/arm/v7 is for 32-bit ARM devices like Raspberry Pi 2/3
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/09-add-integration-test.yaml
+++ b/.github/workflows/09-add-integration-test.yaml
@@ -74,4 +74,8 @@ jobs:
           labels: ${{ steps.docker_meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          # comma seperated list of what OS and architechtures to build for (in parallel)
+          # default is linux/amd64 (the OS of the runner) but you can add more
+          # adding linux/arm64 is recommended for Apple Silicon, Raspberry Pi, AWS Graviton, etc.
+          # linux/arm/v7 is for 32-bit ARM devices like Raspberry Pi 2/3
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/10-add-k8s-test.yaml
+++ b/.github/workflows/10-add-k8s-test.yaml
@@ -93,4 +93,8 @@ jobs:
           labels: ${{ steps.docker_meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          # comma seperated list of what OS and architechtures to build for (in parallel)
+          # default is linux/amd64 (the OS of the runner) but you can add more
+          # adding linux/arm64 is recommended for Apple Silicon, Raspberry Pi, AWS Graviton, etc.
+          # linux/arm/v7 is for 32-bit ARM devices like Raspberry Pi 2/3
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/99-parallelize-jobs.yaml
+++ b/.github/workflows/99-parallelize-jobs.yaml
@@ -255,7 +255,11 @@ jobs:
           labels: ${{ steps.docker_meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          # comma seperated list of what OS and architechtures to build for (in parallel)
+          # default is linux/amd64 (the OS of the runner) but you can add more
+          # adding linux/arm64 is recommended for Apple Silicon, Raspberry Pi, AWS Graviton, etc.
+          # linux/arm/v7 is for 32-bit ARM devices like Raspberry Pi 2/3
+          platforms: linux/amd64,linux/arm64
 
         # If PR, put image tags in the PR comments
         # from https://github.com/marketplace/actions/create-or-update-comment


### PR DESCRIPTION
Due to the reduced use of arm/v7 and the worsening state of getting arm/v7 to build properly, I'm moving it to a comment for optional use and sticking with the default platforms being:

`platforms: linux/amd64,linux/arm64`